### PR TITLE
refactor(cores): fix the import path

### DIFF
--- a/src/cores/entities/presenters/header.presenter.ts
+++ b/src/cores/entities/presenters/header.presenter.ts
@@ -1,4 +1,4 @@
-import { UserDomain } from "@/core/entities/domains/user.domain";
+import { UserDomain } from "@/cores/entities/domains/user.domain";
 
 type THeaderPresenter = {
   title: string;

--- a/src/cores/services/user/index.ts
+++ b/src/cores/services/user/index.ts
@@ -1,4 +1,4 @@
-import { httpClientImpl, httpClientMock } from "@/core/libs/http";
+import { httpClientImpl, httpClientMock } from "@/cores/libs/http";
 
 import { UserServiceImpl } from "./user.impl.service";
 import { UserServiceMock } from "./user.mock.service";

--- a/src/cores/services/user/user.impl.service.ts
+++ b/src/cores/services/user/user.impl.service.ts
@@ -1,8 +1,8 @@
 import { AxiosResponse } from "axios";
 import { map, Observable } from "rxjs";
 
-import { UserDomain } from "@/core/entities/domains/user.domain";
-import { HttpClient } from "@/core/libs/http/http-client";
+import { UserDomain } from "@/cores/entities/domains/user.domain";
+import { HttpClient } from "@/cores/libs/http/http-client";
 
 import { UserService } from "./user.service";
 

--- a/src/cores/services/user/user.mock.service.ts
+++ b/src/cores/services/user/user.mock.service.ts
@@ -1,7 +1,7 @@
 import { BehaviorSubject, Observable } from "rxjs";
 
-import { UserDomain } from "@/core/entities/domains/user.domain";
-import { HttpClient } from "@/core/libs/http/http-client";
+import { UserDomain } from "@/cores/entities/domains/user.domain";
+import { HttpClient } from "@/cores/libs/http/http-client";
 
 import { UserService } from "./user.service";
 

--- a/src/cores/services/user/user.service.ts
+++ b/src/cores/services/user/user.service.ts
@@ -1,7 +1,7 @@
 import { Observable } from "rxjs";
 
-import { UserDomain } from "@/core/entities/domains/user.domain";
-import { HttpClient } from "@/core/libs/http/http-client";
+import { UserDomain } from "@/cores/entities/domains/user.domain";
+import { HttpClient } from "@/cores/libs/http/http-client";
 
 interface IUserService {
   url: string;

--- a/src/cores/usecases/header/header.impl.usecase.ts
+++ b/src/cores/usecases/header/header.impl.usecase.ts
@@ -1,7 +1,7 @@
 import { map, Observable } from "rxjs";
 
-import { HeaderPresenter } from "@/core/entities/presenters/header.presenter";
-import { UserService } from "@/core/services/user/user.service";
+import { HeaderPresenter } from "@/cores/entities/presenters/header.presenter";
+import { UserService } from "@/cores/services/user/user.service";
 
 import { HeaderUsecase } from "./header.usecase";
 

--- a/src/cores/usecases/header/header.mock.usecase.ts
+++ b/src/cores/usecases/header/header.mock.usecase.ts
@@ -1,8 +1,8 @@
 import { BehaviorSubject, Observable } from "rxjs";
 
-import { UserDomain } from "@/core/entities/domains/user.domain";
-import { HeaderPresenter } from "@/core/entities/presenters/header.presenter";
-import { UserService } from "@/core/services/user/user.service";
+import { UserDomain } from "@/cores/entities/domains/user.domain";
+import { HeaderPresenter } from "@/cores/entities/presenters/header.presenter";
+import { UserService } from "@/cores/services/user/user.service";
 
 import { HeaderUsecase } from "./header.usecase";
 

--- a/src/cores/usecases/header/header.usecase.ts
+++ b/src/cores/usecases/header/header.usecase.ts
@@ -1,7 +1,7 @@
 import { Observable } from "rxjs";
 
-import { HeaderPresenter } from "@/core/entities/presenters/header.presenter";
-import { UserService } from "@/core/services/user/user.service";
+import { HeaderPresenter } from "@/cores/entities/presenters/header.presenter";
+import { UserService } from "@/cores/services/user/user.service";
 
 interface HeaderUsecaseI {
   userService: UserService;

--- a/src/cores/usecases/header/index.ts
+++ b/src/cores/usecases/header/index.ts
@@ -1,4 +1,4 @@
-import { userServiceImpl, userServiceMock } from "@/core/services/user";
+import { userServiceImpl, userServiceMock } from "@/cores/services/user";
 
 import { HeaderUsecaseImpl } from "./header.impl.usecase";
 import { HeaderUsecaseMock } from "./header.mock.usecase";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "incremental": true,
     "types": ["@testing-library/jest-dom"],
     "paths": {
-      "@/core/*": ["./src/core/*"],
+      "@/cores/*": ["./src/cores/*"],
       "@/hooks/*": ["./src/hooks/*"],
       "@/libs/*": ["./src/libs/*"],
       "@/utils/*": ["./src/utils/*"],


### PR DESCRIPTION
fix the import path in cores cause of renaming core to cores